### PR TITLE
Fix tests after #15

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -116,7 +116,8 @@ describe('jss-expand', () => {
     it('should generate correct CSS', () => {
       expect(sheet.toString()).to.be(
         '.a-id {\n' +
-        '  background: #000 url(test.jpg) 0 0 no-repeat;\n' +
+        '  background: #000 0 0 no-repeat;\n' +
+        '  background-image: url(test.jpg);\n' +
         '}'
       )
     })
@@ -156,14 +157,12 @@ describe('jss-expand', () => {
       sheet = jss.createStyleSheet({
         a: {
           background: {
-            image: 'linear-gradient(red 0%, green 100%)',
+            color: 'rgba(255, 255, 255, 0.8)',
           },
           padding: 50,
           fallbacks: {
             background: {
-              color: 'url(test.png)',
-              repeat: 'no-repeat',
-              position: [0, 0]
+              color: 'white'
             },
             padding: 20
           }
@@ -178,9 +177,9 @@ describe('jss-expand', () => {
     it('should generate correct CSS', () => {
       expect(sheet.toString()).to.be(
         '.a-id {\n' +
-        '  background: url(test.png) 0 0 no-repeat;\n' +
+        '  background: white;\n' +
         '  padding: 20;\n' +
-        '  background: linear-gradient(red 0%, green 100%);\n' +
+        '  background: rgba(255, 255, 255, 0.8);\n' +
         '  padding: 50;\n' +
         '}'
       )


### PR DESCRIPTION
Fixes tests for https://github.com/cssinjs/jss-expand/pull/15
Now it's all ok.

Found that there are problems with fallbacks (if we use `customPropObj` with fallbacks), I'll create soon a new issue about them with a fix.