### PR TITLE
Correct documentation on `background` property

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -173,9 +173,9 @@ background: {
   attachment: null,
   color: null,
   image: null,
-  position: null, // Can be written using array e.g. `[0, 0]`
+  position: null, // Accepts array notation (e.g., `[0, 0]`, `['center', 'top']`)
   repeat: null,
-  size: null, // Can be written using array e.g. `['center', 'center']`
+  size: null, // Accepts array notation (e.g., `['100%', '50%']`) and keywords (`contain`, `cover`)
 }
 ```
 


### PR DESCRIPTION
As it stands now, the documented `background` property values for `size` (_i.e._, `background-size`) reads
> ```js
> background: {
>   // ...
>   size: null, // Can be written using array e.g. `['center', 'center']`
> }
> ```

+ I have modified this to reflect the fact that `center` is not an accepted keyword for the `background-size` property. More likely the case is that the author intended this for the `background-position` property.